### PR TITLE
SLACKURL 環境変数指定を忘れている時にエラー出力

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,11 @@ func main() {
 	var err error
 	var webHookURL string = os.Getenv("SLACKURL")
 
+	if !strings.Contains(webHookURL, "http") {
+		fmt.Println("Specify SLACKURL envirinment variable and export")
+		return
+	}
+
 	flag.Parse()
 	if flag.NArg() > 1 {
 		err = fmt.Errorf("too many args")


### PR DESCRIPTION
SLACKURL 環境変数を忘れるうっかりさん向けの表示。

SLACKURL 環境変数が定義されていなかった（export されていなかった）場合、 `webHookURL` はいわゆる未定義値なのか空文字列なのかパッとわからなかったのですが、そのあたり良い書き方はあるのであればアドバイス下さい。追加でブランチを修正します。